### PR TITLE
Fix worker error

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,24 +1,36 @@
-from tkinter import filedialog, Tk
 import base64
 import datetime
 import io
 import os
-import time
-from PIL import Image
-import numpy as np
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from tkinter import filedialog, Tk
+
 import gradio as gr
+import numpy as np
+from PIL import Image
 from gradio import Warning
 from openai import OpenAI
-import sys
-import threading
-from concurrent.futures import ThreadPoolExecutor
+
+from threading import Thread
+from rate_limiter import RateLimiter, reset_limiter_periodically
 
 FOLDER_SYMBOL = '\U0001f4c2'  # 📂
 MAX_IMAGE_WIDTH = 2048
 IMAGE_FORMAT = "JPEG"
 
+# assuming a normal user has tier 1 access to the openAI API, you have 10.000 tpm
+# so say 10 image with around 1000 tokens
+rate_limiter = RateLimiter(10, 60)
+
+# Create and start the reset thread
+reset_thread = Thread(target=reset_limiter_periodically, args=(rate_limiter, 60))
+reset_thread.start()
+
 
 def generate_description(api_key, image, prompt, detail, max_tokens):
+
+    rate_limiter.wait()  # wait if we have exhausted our token limit
     try:
         img = Image.fromarray(image) if isinstance(image, np.ndarray) else Image.open(image)
         img = scale_image(img)
@@ -42,6 +54,10 @@ def generate_description(api_key, image, prompt, detail, max_tokens):
         }
 
         response = client.chat.completions.create(**payload)
+
+        # API call is made, so incrementing the call counter
+        rate_limiter.add_call()
+
         return response.choices[0].message.content
 
     except Exception as e:
@@ -74,7 +90,7 @@ def scale_image(img):
 
 def get_dir(file_path):
     dir_path, file_name = os.path.split(file_path)
-    return (dir_path, file_name)
+    return dir_path, file_name
 
 
 def get_folder_path(folder_path=''):

--- a/main.py
+++ b/main.py
@@ -13,24 +13,25 @@ from gradio import Warning
 from openai import OpenAI
 
 from threading import Thread
-from rate_limiter import RateLimiter, reset_limiter_periodically
+
+# from rate_limiter import RateLimiter, reset_limiter_periodically
 
 FOLDER_SYMBOL = '\U0001f4c2'  # 📂
 MAX_IMAGE_WIDTH = 2048
 IMAGE_FORMAT = "JPEG"
 
+
 # assuming a normal user has tier 1 access to the openAI API, you have 10.000 tpm
 # so say 10 image with around 1000 tokens
-rate_limiter = RateLimiter(10, 60)
+# rate_limiter = RateLimiter(10, 60)
 
 # Create and start the reset thread
-reset_thread = Thread(target=reset_limiter_periodically, args=(rate_limiter, 60))
-reset_thread.start()
+# reset_thread = Thread(target=reset_limiter_periodically, args=(rate_limiter, 60))
+# reset_thread.start()
 
 
 def generate_description(api_key, image, prompt, detail, max_tokens):
-
-    rate_limiter.wait()  # wait if we have exhausted our token limit
+    # rate_limiter.wait()  # wait if we have exhausted our token limit
     try:
         img = Image.fromarray(image) if isinstance(image, np.ndarray) else Image.open(image)
         img = scale_image(img)
@@ -56,7 +57,7 @@ def generate_description(api_key, image, prompt, detail, max_tokens):
         response = client.chat.completions.create(**payload)
 
         # API call is made, so incrementing the call counter
-        rate_limiter.add_call()
+        # rate_limiter.add_call()
 
         return response.choices[0].message.content
 
@@ -147,7 +148,6 @@ def process_folder(api_key, folder_path, prompt, detail, max_tokens, pre_prompt=
         with open(txt_path, 'w', encoding='utf-8') as f:
             f.write(pre_prompt + ", " + description + " " + post_prompt)
 
-
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
         for i, _ in enumerate(executor.map(process_file, file_list), 1):
             progress((i, len(file_list)))
@@ -232,14 +232,15 @@ with gr.Blocks() as app:
                         outputs=[output, history_table])
 
 
-    def on_click_folder(api_key, folder_path, prompt, detail, max_tokens, pre_prompt, post_prompt, worker_slider):
+    def on_click_folder(api_key, folder_path, prompt, detail, max_tokens, pre_prompt, post_prompt, worker_slider_local):
         if not api_key.strip():
             raise Warning("Please enter your OpenAI API key.")
 
         if not folder_path.strip():
             raise Warning("Please enter the folder path.")
 
-        result = process_folder(api_key, folder_path, prompt, detail, max_tokens, pre_prompt, post_prompt)
+        result = process_folder(api_key, folder_path, prompt, detail, max_tokens, pre_prompt, post_prompt,
+                                num_workers=worker_slider_local)
         return result
 
 

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,0 +1,31 @@
+import threading
+import time
+
+
+class RateLimiter:
+    def __init__(self, max_calls, period):
+        self.max_calls = max_calls
+        self.period = period
+        self.calls = 0
+        self.lock = threading.Lock()
+
+    def reset(self):
+        with self.lock:
+            self.calls = 0
+
+    def add_call(self):
+        with self.lock:
+            self.calls += 1
+
+    def wait(self):
+        while True:
+            with self.lock:
+                if self.calls < self.max_calls:
+                    break
+            time.sleep(1)
+
+
+def reset_limiter_periodically(limiter, period):
+    while True:
+        time.sleep(period)
+        limiter.reset()


### PR DESCRIPTION
There was definitely a bug in the code:
This line is call originally without the num_workers, which leads to running with 4 worker processes always (because it is the parameter default of process_folder:
        result = process_folder(api_key, folder_path, prompt, detail, max_tokens, pre_prompt, post_prompt,
                                num_workers=worker_slider_local)

More over, I added the rate_limiter class, which throttles the calls after 10 processed images in 1 minute. 
I commented this out, because running with only 1 thread was sufficient to get not a rate limit error.

